### PR TITLE
Rope OreDict support to allow more supported mods.

### DIFF
--- a/src/main/java/c4/comforts/common/blocks/BlockRope.java
+++ b/src/main/java/c4/comforts/common/blocks/BlockRope.java
@@ -10,6 +10,7 @@ package c4.comforts.common.blocks;
 
 import c4.comforts.Comforts;
 import c4.comforts.common.items.ComfortsItems;
+import c4.comforts.common.util.OreDictHelper;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
@@ -33,9 +34,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.oredict.OreDictionary;
 
 public class BlockRope extends Block {
 
+    private static final String ORE_MATCH = "logWood";
     public static final PropertyDirection FACING = PropertyDirection.create("facing", (apply) ->
             apply != EnumFacing.DOWN && apply != EnumFacing.UP
     );
@@ -110,7 +113,7 @@ public class BlockRope extends Block {
         IBlockState iblockstate = worldIn.getBlockState(blockpos);
         Block block = iblockstate.getBlock();
 
-        return facing != EnumFacing.UP && facing != EnumFacing.DOWN && (block instanceof BlockLog || block instanceof BlockPlanks);
+        return facing != EnumFacing.UP && facing != EnumFacing.DOWN && (block instanceof BlockLog || block instanceof BlockPlanks || OreDictHelper.oreDictMatches(ORE_MATCH, iblockstate));
     }
 
     @Override

--- a/src/main/java/c4/comforts/common/util/OreDictHelper.java
+++ b/src/main/java/c4/comforts/common/util/OreDictHelper.java
@@ -1,0 +1,29 @@
+package c4.comforts.common.util;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class OreDictHelper {
+
+    /**
+     * Check to see if a block is registered with a certain oreDict name
+     * @param dictEntry name eg. logWood / oreCopper
+     * @param state block state to search against
+     * @return true if a dictionary matching the dictEntry parameter was found.
+     */
+    public static boolean oreDictMatches(String dictEntry, IBlockState state) {
+        ItemStack stack = new ItemStack(state.getBlock(),1, state.getBlock().getMetaFromState(state));
+        boolean result = false;
+        if(!stack.isEmpty()) {//avoid invalid stack exception
+            int[] ids = OreDictionary.getOreIDs(stack);//get all dict entries for this block
+            for (int i : ids) {//get oreName for each entry
+                //or the result to return true if any matches dictEntry
+                result |= OreDictionary.getOreName(i).contentEquals(dictEntry);
+            }
+            return result;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Added an oreDict category match for blocks.
Added support on rope to also check against logWood in oreDict on canPlaceAt.
Didn't add check for plankWood as this matched stairs which isn't intended afaik.

Natura is now supported as it seems they use a custom base for their tree logs as I am sure other do also.