### PR TITLE
Add support for Farmer's Delight rope in rope-related recipes.

### DIFF
--- a/forge/src/main/resources/data/forge/tags/items/rope.json
+++ b/forge/src/main/resources/data/forge/tags/items/rope.json
@@ -8,6 +8,10 @@
     {
       "id": "supplementaries:rope",
       "required": false
+    },
+    {
+      "id": "farmersdelight:rope",
+      "required": false
     }
   ]
 }


### PR DESCRIPTION
Adds "farmersdelight:rope" to tag #forge:rope