### PR TITLE
[1.21.x] Fix deprecated Forge API usages

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -66,8 +66,6 @@ sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-    // Hack fix for now, force jopt-simple to be exactly 5.0.4 because Mojang ships that version, but some transtive dependencies request 6.0+
-    implementation('net.sf.jopt-simple:jopt-simple:5.0.4') { version { strictly '5.0.4' } }
 
     implementation group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "${spectrelib_version}"
     jarJar(group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "[0.16.1,2.0)") {

--- a/forge/src/main/java/com/illusivesoulworks/comforts/ComfortsForgeClientMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/comforts/ComfortsForgeClientMod.java
@@ -26,12 +26,10 @@ import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class ComfortsForgeClientMod {
 
-  public static void init() {
-    IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
+  public static void init(IEventBus eventBus) {
     eventBus.addListener(ComfortsForgeClientMod::clientSetup);
     eventBus.addListener(ComfortsForgeClientMod::entityRenderers);
     eventBus.addListener(ComfortsForgeClientMod::layerDefinitions);

--- a/forge/src/main/java/com/illusivesoulworks/comforts/ComfortsForgeMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/comforts/ComfortsForgeMod.java
@@ -43,10 +43,10 @@ import net.minecraftforge.common.crafting.conditions.ICondition;
 import net.minecraftforge.data.event.GatherDataEvent;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
-import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -60,11 +60,14 @@ public class ComfortsForgeMod {
   public static final Supplier<MapCodec<? extends ICondition>> HAMMOCK_CONDITION =
       CONDITIONS.register("hammock_enabled", () -> HammockEnabledCondition.CODEC);
 
-  public ComfortsForgeMod() {
+  public ComfortsForgeMod(FMLJavaModLoadingContext context) {
     ComfortsCommonMod.init();
     ComfortsCommonMod.initConfig();
-    DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> ComfortsForgeClientMod::init);
-    IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();
+
+    IEventBus eventBus = context.getModEventBus();
+    if (FMLEnvironment.dist == Dist.CLIENT) {
+      ComfortsForgeClientMod.init(eventBus);
+    }
     CONDITIONS.register(eventBus);
     eventBus.addListener(this::setup);
     eventBus.addListener(this::registerCapabilities);

--- a/forge/src/main/java/com/illusivesoulworks/comforts/client/ComfortsClientEventsListener.java
+++ b/forge/src/main/java/com/illusivesoulworks/comforts/client/ComfortsClientEventsListener.java
@@ -25,9 +25,9 @@ import net.minecraftforge.fml.LogicalSide;
 public class ComfortsClientEventsListener {
 
   @SubscribeEvent
-  public void onTick(final TickEvent.PlayerTickEvent evt) {
+  public void onTick(final TickEvent.PlayerTickEvent.Pre evt) {
 
-    if (evt.phase == TickEvent.Phase.START && evt.side == LogicalSide.CLIENT) {
+    if (evt.side == LogicalSide.CLIENT) {
       ComfortsClientEvents.onTick(evt.player);
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,8 +31,8 @@ fabric_loader_version=0.16.5
 cca_version=6.1.0
 
 # Forge
-forge_version=52.0.1
-forge_version_range=[51,)
+forge_version=52.1.0
+forge_version_range=[52,)
 
 # NeoForge
 neoforge_version=21.1.1


### PR DESCRIPTION
This PR avoids usages of deprecated Forge APIs to help reduce friction when porting to future MC versions.